### PR TITLE
Fix for #26, escaping emojis

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ Example:
 🤣 🪬 🫦 I love LmaoLang! 💀🫦 💀🪬 💀🤣
 ```
 
+I heard you like emojis... 🤦 but how do you use emojis in your documents?
+
+Easy, use the 🪂 emoji to escape emojis!
+🪂 can escape itself too. It can also escape the 💀 modifier.
+Example:
+```
+🪂📦I am a not a div 🪂💀🪂📦 and you can 🪂🪂 escape 🪂🪂 escapes 🪂🪂
+```
+
 ## 📘 API Reference
 
 

--- a/src/__☺️__/tests.☺️.ts
+++ b/src/__☺️__/tests.☺️.ts
@@ -53,3 +53,8 @@ lmaoTestRunner("List Item", () =>
 const articleLmao = "🤓Article💀🤓";
 const expectedArticleHtml = "<article>Article</article>";
 lmaoTestRunner("Article", () => compilerTest(articleLmao, expectedArticleHtml));
+
+// Escaping
+const escapeLmao = "I am a not a div 📦💀🤓";
+const expectedEscapeHtml = "I am a not a div 📦💀🤓";
+lmaoTestRunner("Escape", () => compilerTest(escapeLmao, expectedEscapeHtml));

--- a/src/__☺️__/tests.☺️.ts
+++ b/src/__☺️__/tests.☺️.ts
@@ -55,6 +55,6 @@ const expectedArticleHtml = "<article>Article</article>";
 lmaoTestRunner("Article", () => compilerTest(articleLmao, expectedArticleHtml));
 
 // Escaping
-const escapeLmao = "I am a not a div 📦💀🤓";
-const expectedEscapeHtml = "I am a not a div 📦💀🤓";
-lmaoTestRunner("Escape", () => compilerTest(escapeLmao, expectedEscapeHtml));
+const escapeLmao = "🪂📦I am a not a div 🪂💀🪂📦 and you can 🪂🪂 escape 🪂🪂 escapes 🪂🪂";
+const expectedEscapeHtml = "📦I am a not a div 💀📦 and you can 🪂 escape 🪂 escapes 🪂";
+lmaoTestRunner("Escaping", () => compilerTest(escapeLmao, expectedEscapeHtml));

--- a/src/checkers.ts
+++ b/src/checkers.ts
@@ -13,4 +13,6 @@ export const isEmoji = (char: string) => {
 
 export const isClosingTag = (char: string): boolean => char === "💀";
 
+export const isEscape = (char: string): boolean => char === "🪂";
+
 export const isLegalEmoji = (char: string) => Boolean(tokenMap[char]);

--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -1,5 +1,6 @@
 import {
   isClosingTag,
+  isEscape,
   isEmoji,
   isLegalEmoji,
   isShallNotBeNamed,
@@ -8,21 +9,33 @@ import { tokenMap } from "./tokenMap.js";
 import { Token } from "./types.js";
 import { red } from "./utils/consoleColors.js";
 
+type ModifierType = "closing-tag" | "escape"
+
 const lexer = (lmaoCode: string): Token[] => {
   const tokens: Token[] = [];
   let tempString = "";
-  let lastTokenWasModifier = false;
+  let lastTokenWasModifier: false | ModifierType = false;
 
   for (const char of lmaoCode) {
     let token: Token;
     if (isEmoji(char)) {
-      if (isClosingTag(char)) {
-        lastTokenWasModifier = true;
-        continue;
+      if (lastTokenWasModifier !== "escape") {
+        if (isClosingTag(char)) {
+          lastTokenWasModifier = "closing-tag";
+          continue;
+        } else if (isEscape(char)) {
+          lastTokenWasModifier = "escape";
+          continue;
+        }
       }
 
       if (isLegalEmoji(char)) {
-        if (lastTokenWasModifier) {
+        if (lastTokenWasModifier === "escape") {
+          token = { type: tokenMap.TEXT, value: char };
+          lastTokenWasModifier = false;
+          tokens.push(token);
+          continue;
+        } else if (lastTokenWasModifier === "closing-tag") {
           // @ts-ignore
           token = { type: `CLOSE_${tokenMap[char]}`, value: char };
           lastTokenWasModifier = false;
@@ -33,10 +46,11 @@ const lexer = (lmaoCode: string): Token[] => {
         tokens.push(token);
         continue;
       } else {
+        lastTokenWasModifier = false;
         token = { type: tokenMap.ERROR, value: char };
         tokens.push(token);
       }
-    } else if (!isEmoji(char)) {
+    } else {
       tempString += char;
       if (isShallNotBeNamed(tempString)) {
         console.log(
@@ -45,6 +59,8 @@ const lexer = (lmaoCode: string): Token[] => {
         );
         process.exit(0);
       }
+
+      lastTokenWasModifier = false;
       token = { type: tokenMap.TEXT, value: char };
       tokens.push(token);
     }

--- a/src/tokenMap.ts
+++ b/src/tokenMap.ts
@@ -3,6 +3,7 @@ import { type TokenType } from "./types.js";
 export const tokenMap: Record<string, TokenType> = {
   "🤣": "HTML",
   "💀": "💀",
+  "🪂": "🪂",
   "🪬": "BODY",
   "🫦": "H1",
   "📦": "DIV",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 export type TokenType =
   | "HTML"
   | "💀"
+  | "🪂"
   | "BODY"
   | "H1"
   | "TEXT"


### PR DESCRIPTION
This PR introduces the 🪂 escape emoji so that we can use emojis in our documents.

https://github.com/QuantGeekDev/lmaolang/issues/26